### PR TITLE
Added previews of each logo and links to the raw

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,32 +1,49 @@
 #Curated list of png/svg web-dev logos
 
 ### Currently:
-1. angular
-2. babel
-2. bourbon
-2. bower
-3. browserify
-3. css3
-4. firebase
-5. full mean stack
-5. github
-6. grunt
-7. gulp
-8. html5
-8. jade
-9. jasmine
-10. jQuery
-11. javascript
-12. mocha
-13. mongo DB
-14. nodejs
-15. npm
-16. postgres
-16. react
-16. redux
-16. sass
-16. tape
-17. yeoman
+
+1. [angular](angular.png)<img src="angular.png" height="40">
+1. [babel](babel.png)<img src="babel.png" height="40">
+1. [bourbon with text](bourbon-logo-2.png)<img src="bourbon-logo-2.png" height="40">
+1. [bourbon logo only](bourbon-logo.png)<img src="bourbon-logo.png" height="40">
+1. [bower](bower.png)<img src="bower.png" height="40">
+1. [browserify](browserify.png)<img src="browserify.png" height="40">
+1. [browserify2](browserify2.png)<img src="browserify2.png" height="40">
+1. [css3](css3.png)<img src="css3.png" height="40">
+1. [firebase](firebase.png)<img src="firebase.png" height="40">
+1. [full mean stack](fullMean.png)<img src="fullMean.png" height="40">
+1. [github](github.png)<img src="github.png" height="40">
+1. [grunt](grunt.ong.png)<img src="grunt.ong.png" height="40">
+1. [gulp](gulp.png)<img src="gulp.png" height="40">
+1. [html5](html5.png)<img src="html5.png" height="40">
+1. [jade](jade.png)<img src="jade.png" height="40">
+1. [jasmine svg](jasmine.svg)<img src="jasmine.png" height="40">
+1. [javascript](jslogo.png.png)<img src="jslogo.png.png" height="40">
+1. [jquery](jquery.png)<img src="jquery.png" height="40">
+1. [mocha](mocha.png)<img src="mocha.png" height="40">
+1. [mongo DB](mongo.png)<img src="mongo.png" height="40">
+1. [nodejs svg](nodejs.png)<img src="nodejs.png" height="40">
+1. [npm](npm.png)<img src="npm.png" height="40">
+1. [postgres](postgres.png)<img src="postgres.png" height="40">
+1. [react](react.png)<img src="react.png" height="40">
+1. [redux](redux.png)<img src="redux.png" height="40">
+1. [sass](sass.png)<img src="sass.png" height="40">
+1. [tape](tape.png)<img src="tape.png" height="40">
+1. [yeoman](yeoman-logo.png)<img src="yeoman-logo.png" height="40">
+1. [](yeoman-logo.png)<img src="yeoman-logo.png" height="40">
 
 
-Feel free to add your own, just make a PR!
+Feel free to add your own, just make a PR DEWD.jpg!
+
+
+***
+### Adding to the List
+#### Formatting
+1. [angular](angular.png)<img src="angular.png" height="40">   
+Format:  
+`1. [text to display](imageName.file)<imc src="imageName.file" height="desired height in pixels">  `
+
+* The "1." at the beginning of the line stays the same throughout the list (markup knows to increment for you)  
+* The two instances of (imageName.file) are doing different things:  
+  * `[angular](angular.png)` - sets it as a link to the github source file page (then you'll want to right click and copy img location)  
+  * `<img src="angular.png" height="40">` - sets up the image in the README and sets the size to a height of 40px  


### PR DESCRIPTION
1. [angular](angular.png)<img src="angular.png" height="40">  
   Format:  `1. [text to display](imageName.file)<imc src="imageName.file" height="desired height in pixels">`
- The "1." at the beginning of the line stays the same throughout the list (markup knows to increment for you)  
- The two instances of (imageName.file) are doing different things:  
  - `[angular](angular.png)` - sets it as a link to the github source file page (then you'll want to right click and copy img location)  
  - `<img src="angular.png" height="40">` - sets up the image in the README and sets the size to a height of 40px
